### PR TITLE
Add clients to server query

### DIFF
--- a/api/src/models/server.rs
+++ b/api/src/models/server.rs
@@ -10,6 +10,7 @@ use libwgbuilder::models::VpnIp as DbVpnIp;
 use crate::{auth::ServerGuard, schema::get_db_connection};
 
 use super::vpn_ip::NewVpnIp;
+use super::Client;
 use super::Keypair;
 use super::VpnIp;
 
@@ -54,6 +55,16 @@ impl Server {
         let mut db = get_db_connection(ctx)?;
         let server = DbServer::find(self.id, &mut db)?;
         server.configuration(&mut db)
+    }
+
+    async fn clients(&self, ctx: &Context<'_>) -> Result<Vec<Client>> {
+        let mut db = get_db_connection(ctx)?;
+        let server = DbServer::find(self.id, &mut db)?;
+        Ok(server
+            .get_associated_clients(&mut db)?
+            .into_iter()
+            .map(|c| Client::from(c))
+            .collect())
     }
 }
 


### PR DESCRIPTION
It should be possible to get the clients that are associated with a server. Therefor add clients as a field in the api server model and add a resolve function to the library which resolves the associated clients of a server.

Closing #187