### PR TITLE
Remove redundant ServerGuard check

### DIFF
--- a/api/src/models/server.rs
+++ b/api/src/models/server.rs
@@ -50,7 +50,6 @@ impl Server {
         Ok(VpnIp::from(DbVpnIp::find(client.vpn_ip_id, &mut db)?))
     }
 
-    #[graphql(guard = "ServerGuard::new(self.id)")]
     async fn configuration(&self, ctx: &Context<'_>) -> Result<String> {
         let mut db = get_db_connection(ctx)?;
         let server = DbServer::find(self.id, &mut db)?;


### PR DESCRIPTION
The ServerGuard is already checked on the server query. Because of this it is not necessary to check it again on the configuration field. This additional check is currently implemented and makes it impossible to get the configuration of a server as an administrator.

Solution: Remove the duplicate check on the configuration field.

Closes #215 