### PR TITLE
Remove generate_keypair mutation

### DIFF
--- a/api/src/models/client.rs
+++ b/api/src/models/client.rs
@@ -92,6 +92,5 @@ pub struct NewClient {
     pub description: Option<String>,
     pub dns_server_id: Option<i32>,
     pub keepalive: i32,
-    pub keypair_id: i32,
     pub vpn_ip: NewVpnIp,
 }

--- a/api/src/models/server.rs
+++ b/api/src/models/server.rs
@@ -7,7 +7,7 @@ use libwgbuilder::models::Model;
 use libwgbuilder::models::Server as DbServer;
 use libwgbuilder::models::VpnIp as DbVpnIp;
 
-use crate::{auth::ServerGuard, schema::get_db_connection};
+use crate::schema::get_db_connection;
 
 use super::vpn_ip::NewVpnIp;
 use super::Client;
@@ -72,7 +72,6 @@ pub struct NewServer {
     pub name: String,
     pub description: Option<String>,
     pub forward_interface: Option<String>,
-    pub keypair_id: i32,
     pub external_ip: String,
     pub vpn_ip: NewVpnIp,
 }


### PR DESCRIPTION
The mutation is unnecessary. There is no other reason for a keypair than for new clients or servers. For a better usability the generation of the keypair should happen in the background when creating a client or server.

* Remove generate_keypair mutation
* Remove keypair_id from NewClient and NewServer types
* Generate keypair in new_client and new_server mutation

Closes #172